### PR TITLE
portable way to execute ruby

### DIFF
--- a/preview_report.rb
+++ b/preview_report.rb
@@ -1,4 +1,4 @@
-#!/opt/puppet/bin/ruby
+#!/usr/bin/env ruby
 require 'markaby'
 require 'json'
 require 'uri'


### PR DESCRIPTION
prior to this commit preview_report was only compatible with puppet 3
location of ruby has changed in puppet 4. this change allows user to
select appropriate ruby via PATH
